### PR TITLE
NewLunarYear：在defer中释放锁，防止内存泄漏

### DIFF
--- a/calendar/LunarYear.go
+++ b/calendar/LunarYear.go
@@ -33,6 +33,7 @@ type LunarYear struct {
 
 func NewLunarYear(lunarYear int) *LunarYear {
 	lock.Lock()
+	defer lock.Unlock()
 	var year *LunarYear
 	if nil == CACHE_YEAR || CACHE_YEAR.year != lunarYear {
 		year = new(LunarYear)
@@ -54,7 +55,6 @@ func NewLunarYear(lunarYear int) *LunarYear {
 	} else {
 		year = CACHE_YEAR
 	}
-	lock.Unlock()
 	return year
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/6tail/lunar-go
+module github.com/azhang/lunar-go
 
 go 1.14


### PR DESCRIPTION
move `lock.Unlock()` to defer one to avoid memory leak.

if the program panic between lock.Lock() and lock.Unlock(), it will cause memory leak. Move the lock.Unlock to defer block could solve the kind issues